### PR TITLE
fix entitlements.xml (was one line short)

### DIFF
--- a/entitlements.xml
+++ b/entitlements.xml
@@ -7,3 +7,4 @@
 	<key>com.apple.QuartzCore.debug</key>
 	<true/>
 </dict>
+</plist>


### PR DESCRIPTION
nice work on this project, I noticed that the entitlements file was missing a line at the bottom (`</plist>`) making it invalid, should be fixed now.